### PR TITLE
Resolve symbol types in symbol table

### DIFF
--- a/src/json-symtab-language/json_symtab_language.cpp
+++ b/src/json-symtab-language/json_symtab_language.cpp
@@ -11,6 +11,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include "json_symtab_language.h"
 #include <json/json_parser.h>
 #include <util/json_symbol_table.h>
+#include <util/namespace.h>
 
 bool json_symtab_languaget::parse(
   std::istream &instream,
@@ -30,12 +31,58 @@ bool json_symtab_languaget::typecheck(
   try
   {
     symbol_table_from_json(parsed_json_file, symbol_table);
+    follow_type_symbols(symbol_table);
     return false;
   }
   catch(const std::string &str)
   {
     error() << "json_symtab_languaget::typecheck: " << str << eom;
     return true;
+  }
+}
+
+void json_symtab_languaget::follow_type_symbols(
+  irept &irep,
+  const namespacet &ns)
+{
+  ns.follow_type_symbol(irep);
+
+  for(irept &sub : irep.get_sub())
+  {
+    follow_type_symbols(sub, ns);
+  }
+
+  for(auto &entry : irep.get_named_sub())
+  {
+    irept &sub = entry.second;
+
+    follow_type_symbols(sub, ns);
+  }
+}
+
+void json_symtab_languaget::follow_type_symbols(symbol_tablet &symbol_table)
+{
+  const namespacet ns(symbol_table);
+
+  std::vector<irep_idt> type_symbol_names;
+
+  for(auto &entry : symbol_table)
+  {
+    symbolt &symbol = symbol_table.get_writeable_ref(entry.first);
+
+    if(symbol.is_type)
+    {
+      type_symbol_names.push_back(symbol.name);
+    }
+
+    // Modify entries in place
+    follow_type_symbols(symbol.type, ns);
+    follow_type_symbols(symbol.value, ns);
+  }
+
+  for(const irep_idt &id : type_symbol_names)
+  {
+    symbol_table.remove(id);
   }
 }
 

--- a/src/json-symtab-language/json_symtab_language.h
+++ b/src/json-symtab-language/json_symtab_language.h
@@ -60,6 +60,9 @@ class json_symtab_languaget:public languaget
   }
 
  protected:
+  void follow_type_symbols(symbol_tablet &symbol_table);
+  void follow_type_symbols(irept &irep, const namespacet &ns);
+
   jsont parsed_json_file;
 };
 

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -38,6 +38,7 @@ SRC = arith_tools.cpp \
       json_expr.cpp \
       json_irep.cpp \
       json_stream.cpp \
+      json_symbol.cpp \
       json_symbol_table.cpp \
       lispexpr.cpp \
       lispirep.cpp \

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -67,6 +67,23 @@ void namespace_baset::follow_symbol(irept &irep) const
   }
 }
 
+void namespace_baset::follow_type_symbol(irept &irep) const
+{
+  while(irep.id() == ID_symbol)
+  {
+    const symbolt &symbol = lookup(irep);
+
+    if(symbol.is_type && !symbol.type.is_nil())
+    {
+      irep = symbol.type;
+    }
+    else
+    {
+      break;
+    }
+  }
+}
+
 const typet &namespace_baset::follow(const typet &src) const
 {
   if(src.id()!=ID_symbol)

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -43,6 +43,7 @@ public:
   virtual ~namespace_baset();
 
   void follow_symbol(irept &irep) const;
+  void follow_type_symbol(irept &irep) const;
   void follow_macros(exprt &expr) const;
   const typet &follow(const typet &src) const;
 

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -179,7 +179,7 @@ public:
       return &**this;
     }
 
-    symbolt &get_writeable_symbol(const irep_idt &identifier)
+    symbolt &get_writeable_symbol()
     {
       if(on_get_writeable)
         on_get_writeable((*this)->first);


### PR DESCRIPTION
This resolves the type symbols to the pointed-to types in the symbol table before creating the goto program, when reading a json goto program file.